### PR TITLE
댓글, 게시글 작성시 10분동안 최대 1회만 지급받을 수 있도록합니다.

### DIFF
--- a/app/consumer/src/main/kotlin/com/anycommunity/consumer/batch/OutboxRetryScheduler.kt
+++ b/app/consumer/src/main/kotlin/com/anycommunity/consumer/batch/OutboxRetryScheduler.kt
@@ -4,7 +4,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import com.anycommunity.domain.shared.outbox.OutboxRetryHandler
-import com.anycommunity.infra.redis.lock.executeIfAcquired
+import com.anycommunity.infra.redis.lock.timeBoundLock
 
 // 서비스 규모가 아직 작고, 배치 로직 하나를 처리하기 위해 배치 서버를 별도로 구성하는 것은 투 머치하다고 판단,
 // 임시적으로 컨슈머 모듈 내에서 스케줄러 방식으로 배치 작업을 처리
@@ -17,7 +17,7 @@ class OutboxRetryScheduler(
     @Scheduled(fixedRate = 600000) // 10분마다 실행
     fun retry() {
         // 서버가 여러대인 경우 스케줄러가 여러 번 실행될 수 있어, 한 번만 실행되도록 제한
-        executeIfAcquired(key = "outbox-retry", leaseTime = 60, transactional = true) {
+        timeBoundLock(key = "outbox-retry", leaseTime = 60, transactional = true) {
             outboxRetryHandler.retry()
         }
     }

--- a/infra/redis/src/integrationTest/kotlin/com/anycommunity/infra/redis/lock/TimeBoundLockHandlerTest.kt
+++ b/infra/redis/src/integrationTest/kotlin/com/anycommunity/infra/redis/lock/TimeBoundLockHandlerTest.kt
@@ -1,0 +1,41 @@
+package com.anycommunity.infra.redis.lock
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.data.redis.core.RedisTemplate
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import com.anycommunity.infra.redis.IntegrationTest
+
+internal class TimeBoundLockHandlerTest(
+    private val redisTemplate: RedisTemplate<String, String>,
+) : IntegrationTest, DescribeSpec(
+    {
+        val key = UUID.randomUUID().toString()
+        redisTemplate.delete(key)
+
+        describe("TimeBoundLock 테스트") {
+            it("10개 쓰레드에서 동시에 수행 후 최초 요청만 처리되었는지 확인") {
+                var count = 0
+                val latch = CountDownLatch(10)
+                Executors.newFixedThreadPool(10).apply {
+                    repeat(10) {
+                        execute {
+                            try {
+                                timeBoundLock(key = key, leaseTime = 1, timeUnit = TimeUnit.SECONDS) {
+                                    count++
+                                }
+                            } finally {
+                                latch.countDown()
+                            }
+                        }
+                    }
+                }
+                latch.await()
+                count shouldBe 1
+            }
+        }
+    },
+)

--- a/infra/redis/src/main/kotlin/com/anycommunity/infra/redis/lock/DistributedLockHandler.kt
+++ b/infra/redis/src/main/kotlin/com/anycommunity/infra/redis/lock/DistributedLockHandler.kt
@@ -37,6 +37,11 @@ class DistributedLockForTransaction {
     fun <T> proceed(function: () -> T) = function()
 }
 
+/**
+ * 분산 환경에서 락을 획득하여 주어진 로직을 실행한다.
+ * 락을 획득하지 못하면 CannotAcquireLockException 에러를 던진다.
+ * 로직 실행이 끝난 후에는 락을 반환하며, 설정된 시간이 지나도 자동으로 락이 해제된다.
+ */
 fun <T> distributedLock(
     key: String,
     waitTime: Long = 10L,

--- a/infra/redis/src/main/kotlin/com/anycommunity/infra/redis/lock/ExecuteIfAcquiredHandler.kt
+++ b/infra/redis/src/main/kotlin/com/anycommunity/infra/redis/lock/ExecuteIfAcquiredHandler.kt
@@ -37,6 +37,11 @@ class ExecuteIfAcquiredForTransaction {
     fun <T> proceed(function: () -> T) = function()
 }
 
+/**
+ * 락을 획득한 경우에만 주어진 로직을 실행한다.
+ * 락 획득에 실패하면 로직은 실행하지 않고 무시하고 넘어간다.
+ * 로직 실행이 끝난 후에는 락을 반환하며, 설정된 시간이 지나도 자동으로 락이 해제된다.
+ */
 fun executeIfAcquired(
     key: String,
     leaseTime: Long = 5L,

--- a/infra/redis/src/main/kotlin/com/anycommunity/infra/redis/lock/TimeBoundLockHandler.kt
+++ b/infra/redis/src/main/kotlin/com/anycommunity/infra/redis/lock/TimeBoundLockHandler.kt
@@ -1,0 +1,61 @@
+package com.anycommunity.infra.redis.lock
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.TimeUnit
+import com.anycommunity.infra.redis.lock.TimeBoundLockHandler.Companion.redisTemplate
+import com.anycommunity.infra.redis.lock.TimeBoundLockHandler.Companion.timeBoundLockForTransaction
+
+@Component
+class TimeBoundLockHandler(
+    redisTemplate: RedisTemplate<String, String>,
+    timeBoundLockForTransaction: TimeBoundLockForTransaction,
+) {
+    init {
+        Companion.redisTemplate = redisTemplate
+        Companion.timeBoundLockForTransaction = timeBoundLockForTransaction
+    }
+
+    companion object {
+        internal lateinit var redisTemplate: RedisTemplate<String, String>
+            private set
+
+        internal lateinit var timeBoundLockForTransaction: TimeBoundLockForTransaction
+            private set
+    }
+}
+
+@Component
+class TimeBoundLockForTransaction {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun <T> proceed(function: () -> T) = function()
+}
+
+/**
+ * 설정된 시간 동안 락을 점유하며, 시간이 지나야만 락이 해제된다.
+ * 락을 획득하지 못하면 로직은 실행하지 않고 무시하고 넘어간다.
+ * 로직 실행이 끝난 후에도 락은 반환되지 않고 설정된 시간 동안 유지된다.
+ */
+fun timeBoundLock(
+    key: String,
+    leaseTime: Long = 5L,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+    transactional: Boolean = false,
+    function: () -> Unit,
+) {
+    val lockKey = REDIS_TIME_BOUND_LOCK_KEY_PREFIX + key
+    val lockValue = Thread.currentThread().name
+    val acquired = redisTemplate.opsForValue().setIfAbsent(lockKey, lockValue, leaseTime, timeUnit) ?: false
+
+    if (acquired) {
+        if (transactional) {
+            timeBoundLockForTransaction.proceed(function)
+        } else {
+            function.invoke()
+        }
+    }
+}
+
+private const val REDIS_TIME_BOUND_LOCK_KEY_PREFIX = "timeBoundLock:"


### PR DESCRIPTION
- TimeBoundLock 정의
  - 설정된 시간 동안 락을 점유, 로직 성공여부와 상관없이 시간이 지나야만 락 반환
- 댓글, 게시글 작성시 10분동안 최대 1회만 지급받을 수 있도록합니다.