### PR TITLE
소나큐브 Maintainability 이슈 수정

### DIFF
--- a/infra/mysql/build.gradle.kts
+++ b/infra/mysql/build.gradle.kts
@@ -6,10 +6,9 @@ plugins {
 
 dependencies {
     implementation(project(":definition"))
+    implementation(Dependencies.KDSL.KOTLIN_JDSL_JAKARATA)
 
     runtimeOnly(Dependencies.Mysql.CONNECTOR)
-
-    implementation(Dependencies.KDSL.KOTLIN_JDSL_JAKARATA)
 
     testFixturesImplementation(Dependencies.SpringBoot.SPRING_BOOT_STARTER_TEST)
     testFixturesImplementation(Dependencies.TestContainers.JUNIT_JUPITER)

--- a/infra/redis/src/main/kotlin/com/anycommunity/infra/redis/lock/ExecuteIfAcquiredHandler.kt
+++ b/infra/redis/src/main/kotlin/com/anycommunity/infra/redis/lock/ExecuteIfAcquiredHandler.kt
@@ -61,7 +61,7 @@ fun executeIfAcquired(
                 function()
             }
         } finally {
-            if (redisTemplate.opsForValue().get(lockKey) == lockValue) {
+            if (redisTemplate.opsForValue()[lockKey] == lockValue) {
                 redisTemplate.delete(lockKey)
             } else {
                 log.warn { "작업이 완료되기 전 락이 해제되었습니다. lockKey: $lockKey" }


### PR DESCRIPTION
1. Group dependencies by their destination 
- 의존성 그룹화
2. Replace function call with indexed accessor
- get(key) ->  [key] 
