### PR TITLE
포인트 게임 히스토리 조회 캐시 삭제

### DIFF
--- a/core/usecase/src/integrationTest/kotlin/com/anycommunity/usecase/point/usecase/query/GetPointHistoryUsecaseTest.kt
+++ b/core/usecase/src/integrationTest/kotlin/com/anycommunity/usecase/point/usecase/query/GetPointHistoryUsecaseTest.kt
@@ -26,11 +26,6 @@ internal class GetPointHistoryUsecaseTest(
                 val offset = (page - 1) * size
                 val sortedTransactions = transactions.sortedByDescending { it.id }.drop(offset).take(size)
                 result.content.map { it.amount } shouldBe sortedTransactions.map { it.amount }
-
-                // cache test
-                pointTransactionFixture.persist(userId = userId)
-                val cachedResult = getPointHistoryUsecase(GetPointHistoryQuery(userId, page, size))
-                result shouldBe cachedResult
             }
         }
     },

--- a/core/usecase/src/main/kotlin/com/anycommunity/usecase/point/usecase/query/GetPointHistoryUsecase.kt
+++ b/core/usecase/src/main/kotlin/com/anycommunity/usecase/point/usecase/query/GetPointHistoryUsecase.kt
@@ -2,9 +2,7 @@ package com.anycommunity.usecase.point.usecase.query
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.Duration
 import com.anycommunity.domain.point.service.PointTransactionQueryService
-import com.anycommunity.infra.redis.cache.cached
 import com.anycommunity.usecase.point.port.query.model.GetPointHistoryQuery
 import com.anycommunity.usecase.point.port.query.model.GetPointHistoryResult
 import com.anycommunity.util.custompage.toCustomPage
@@ -14,12 +12,8 @@ class GetPointHistoryUsecase(
     private val pointTransactionQueryService: PointTransactionQueryService,
 ) {
     @Transactional(readOnly = true)
-    operator fun invoke(query: GetPointHistoryQuery) = cached(
-        key = "GetPointHistoryUsecase:${query.hashCode()}",
-        expire = Duration.ofMinutes(10),
-    ) {
+    operator fun invoke(query: GetPointHistoryQuery) =
         pointTransactionQueryService.findByUserIdOrderByIdDesc(query.userId, query.pageable())
             .map { GetPointHistoryResult.from(it) }
             .toCustomPage()
-    }
 }


### PR DESCRIPTION
포인트 받고 바로 기록보고싶은데.. 캐시 때문에 바로 확인이 안되어서 캐시 제거함
개인 유저의 포인트 히스토리 조회(user_id 인덱스 탐)기도하고 캐시가 필수적이진 않아 제거함
- 이후 evict 처리방식, 정책에 대해서도 고민이 필요할듯.. 